### PR TITLE
Add random string implementation, remove generate-password-browser library

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "@vitejs/plugin-react": "^4.3.4",
         "bootstrap": "^5.3.3",
         "camelcase": "^8.0.0",
-        "generate-password-browser": "^1.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0",

--- a/src/generator/CommonPasswordInterface.jsx
+++ b/src/generator/CommonPasswordInterface.jsx
@@ -3,7 +3,7 @@
  */
 
 import { useState, useEffect } from "react"
-import { generate } from "generate-password-browser"
+import { generateRandomString } from "./logic/randomStringGenerator"
 
 function CommonPasswordInterface({ setGeneratedPassword, regenerateCounter }) {
     const DEFAULT_LENGTH = 12
@@ -17,13 +17,13 @@ function CommonPasswordInterface({ setGeneratedPassword, regenerateCounter }) {
     const [specialChars, setSpecialChars] = useState(DEFAULT_SPECIAL_CHARS)
 
     useEffect(() => {
-        const res = generate({
+        const res = generateRandomString(
             length,
             numbers,
-            symbols: specialChars,
-            lowercase: letters,
-            uppercase: letters,
-        })
+            letters,
+            letters,
+            specialChars
+        )
 
         setGeneratedPassword(res)
     }, [length, letters, numbers, specialChars, regenerateCounter])

--- a/src/generator/logic/diceGenerator.js
+++ b/src/generator/logic/diceGenerator.js
@@ -5,8 +5,7 @@
 import camelCase from "camelcase"
 
 import { words } from "./../util/effLargeWordlist"
-
-const SPECIAL_CHARS = "!$&/()=?*+#_.:"
+import { SPECIAL_CHARS } from "./../util/charCollections"
 
 /**
  * Generate dice passphrase

--- a/src/generator/logic/randomStringGenerator.js
+++ b/src/generator/logic/randomStringGenerator.js
@@ -1,0 +1,44 @@
+/**
+ * PassPanda | random string generator implementation
+ */
+
+import {
+    UPPERCASE_LETTERS,
+    LOWERCASE_LETTERS,
+    NUMBERS,
+    SPECIAL_CHARS,
+} from "./../util/charCollections"
+
+/**
+ * Generate random string
+ * @param {number} length String length
+ * @param {boolean} numbers Use numbers
+ * @param {boolean} uppercaseLetters Use uppercase letters
+ * @param {boolean} lowercaseLetters Use lowercase letters
+ * @param {boolean} specialChars Use special characters
+ * @returns {string} generated random string
+ */
+export const generateRandomString = (
+    length,
+    numbers,
+    uppercaseLetters,
+    lowercaseLetters,
+    specialChars
+) => {
+    let chars = ""
+
+    if (numbers) chars += NUMBERS
+    if (uppercaseLetters) chars += UPPERCASE_LETTERS
+    if (lowercaseLetters) chars += LOWERCASE_LETTERS
+    if (specialChars) chars += SPECIAL_CHARS
+
+    const charArray = Array.from(chars)
+
+    const randomValues = new Uint32Array(length)
+    window.crypto.getRandomValues(randomValues)
+
+    return Array.from(
+        randomValues,
+        (value) => charArray[value % charArray.length]
+    ).join("")
+}

--- a/src/generator/util/charCollections.js
+++ b/src/generator/util/charCollections.js
@@ -1,0 +1,8 @@
+/**
+ * PassPanda | char collections
+ */
+
+export const UPPERCASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+export const LOWERCASE_LETTERS = "abcdefghijklmnopqrstuvwxyz"
+export const NUMBERS = "0123456789"
+export const SPECIAL_CHARS = "!@#$%^&*()-_=+[]{}|;:'\",.<>?/"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,13 +2789,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
-  version: 1.5.1
-  resolution: "base64-js@npm:1.5.1"
-  checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
-  languageName: node
-  linkType: hard
-
 "bootstrap@npm:^5.3.3":
   version: 5.3.3
   resolution: "bootstrap@npm:5.3.3"
@@ -2853,16 +2846,6 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: 10c0/db7ebc1733cf471e0b490b4f47e3e2ea2947ce417192c9246644e92c667dd56a71406cc58f62ca7587caf828364892e9952904a02b7aead752bc65b62a37cfe9
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
-  dependencies:
-    base64-js: "npm:^1.3.1"
-    ieee754: "npm:^1.2.1"
-  checksum: 10c0/2a905fbbcde73cc5d8bd18d1caa23715d5f83a5935867c2329f0ac06104204ba7947be098fe1317fbd8830e26090ff8e764f08cd14fefc977bb248c3487bcbd0
   languageName: node
   linkType: hard
 
@@ -4085,16 +4068,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"generate-password-browser@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "generate-password-browser@npm:1.1.0"
-  dependencies:
-    buffer: "npm:^6.0.3"
-    randombytes: "npm:^2.0.5"
-  checksum: 10c0/f929d4dd960a63961e77d85dc815e650c2b6a7372dcd2f84d89592df6ce86c8ec4d0b1e8daa158ff5f4169cde2b460a57a9958cb847f6c4ff7636c30e471483e
-  languageName: node
-  linkType: hard
-
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -4339,13 +4312,6 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
-  languageName: node
-  linkType: hard
-
-"ieee754@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "ieee754@npm:1.2.1"
-  checksum: 10c0/b0782ef5e0935b9f12883a2e2aa37baa75da6e66ce6515c168697b42160807d9330de9a32ec1ed73149aea02e0d822e572bca6f1e22bdcbd2149e13b050b17bb
   languageName: node
   linkType: hard
 
@@ -5392,7 +5358,6 @@ __metadata:
     eslint: "npm:^8.57.0"
     eslint-config-react-app: "npm:^7.0.1"
     eslint-plugin-jsdoc: "npm:^50.0.0"
-    generate-password-browser: "npm:^1.1.0"
     prettier: "npm:^3.2.5"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -5542,15 +5507,6 @@ __metadata:
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: 10c0/900a93d3cdae3acd7d16f642c29a642aea32c2026446151f0778c62ac089d4b8e6c986811076e1ae180a694cedf077d453a11b58ff0a865629a4f82ab558e102
-  languageName: node
-  linkType: hard
-
-"randombytes@npm:^2.0.5":
-  version: 2.1.0
-  resolution: "randombytes@npm:2.1.0"
-  dependencies:
-    safe-buffer: "npm:^5.1.0"
-  checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
   languageName: node
   linkType: hard
 
@@ -5906,13 +5862,6 @@ __metadata:
     has-symbols: "npm:^1.1.0"
     isarray: "npm:^2.0.5"
   checksum: 10c0/43c86ffdddc461fb17ff8a17c5324f392f4868f3c7dd2c6a5d9f5971713bc5fd755667212c80eab9567595f9a7509cc2f83e590ddaebd1bd19b780f9c79f9a8d
-  languageName: node
-  linkType: hard
-
-"safe-buffer@npm:^5.1.0":
-  version: 5.2.1
-  resolution: "safe-buffer@npm:5.2.1"
-  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Remove unmaintained generate-password-browser library, and as there was no maintained and popular equal library, created own implementation for generating random strings.